### PR TITLE
1. Fixed the incomplete task in Reg. step 3 (Add HRA), now it works

### DIFF
--- a/LivingMessiah.Web/LivingMessiah.Web.csproj
+++ b/LivingMessiah.Web/LivingMessiah.Web.csproj
@@ -118,5 +118,9 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Pages\Sukkot\RegistrationSteps\Data\" />
+  </ItemGroup>
+
 
 </Project>

--- a/LivingMessiah.Web/Pages/Home/SectionMain.razor
+++ b/LivingMessiah.Web/Pages/Home/SectionMain.razor
@@ -9,6 +9,10 @@
 		<AudioVisualButton></AudioVisualButton>
 	</AuthorizeView>
 
+	<AuthorizeView Roles=@Roles.Sukkot>
+		<SukkotAdminButton></SukkotAdminButton>
+	</AuthorizeView>
+
 	<AuthorizeView Roles=@Roles.AdminOrKeyDates>
 		@*<KeyDatesEditButton></KeyDatesEditButton>*@
 	</AuthorizeView>

--- a/LivingMessiah.Web/Pages/Home/SukkotAdminButton.razor
+++ b/LivingMessiah.Web/Pages/Home/SukkotAdminButton.razor
@@ -1,0 +1,20 @@
+﻿@using LivingMessiah.Web.Links
+
+
+<div class="list-group">
+	<div class="card mb-3 bg-warning">
+		<div class="card-body">
+
+			<i class="@Sukkot.RegistrationEntry.SuperUser.Icon" aria-hidden="true"></i>
+			<a href="@Sukkot.RegistrationEntry.SuperUser.Index" title="@Sukkot.RegistrationEntry.SuperUser.Title">
+				@Sukkot.RegistrationEntry.SuperUser.Title
+			</a>
+
+		</div>
+	</div>
+</div>
+
+
+@code {
+
+}

--- a/LivingMessiah.Web/Pages/Sukkot/Details/Index.razor.cs
+++ b/LivingMessiah.Web/Pages/Sukkot/Details/Index.razor.cs
@@ -42,6 +42,10 @@ public partial class Index
 		{
 			vwRegistration = await svc!.Details(Id, User, showPrintInstructionMessage);
 		}
+		catch (UserNotAuthoirizedException userNotAuthoirizedException)
+		{
+			Toast!.ShowInfo(userNotAuthoirizedException.Message);
+		}
 		catch (InvalidOperationException invalidOperationException)
 		{
 			Toast!.ShowError($"{invalidOperationException.Message}");

--- a/LivingMessiah.Web/Pages/Sukkot/RegistrationEntry/SuperUser/Index.razor
+++ b/LivingMessiah.Web/Pages/Sukkot/RegistrationEntry/SuperUser/Index.razor
@@ -15,7 +15,7 @@
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<AuthorizeView Roles="@Roles.AdminOrAnnouncements">
+<AuthorizeView Roles="@Roles.AdminOrSukkot">
 	<Authorized>
 
 		<!-- ToDo: can this be moved to <PageHeader ??? -->
@@ -45,8 +45,6 @@
 			{
 				<LivingMessiah.Web.Pages.Sukkot.RegistrationEntry.HouseRulesAgreement.UseAgreementForm />
 			}
-
-			
 
 			<div class="@MediaQuery.XsOrSm.DivClass">
 				<MasterList IsXsOrSm="true" />

--- a/LivingMessiah.Web/Pages/Sukkot/RegistrationSteps/AgreementButtons.razor.cs
+++ b/LivingMessiah.Web/Pages/Sukkot/RegistrationSteps/AgreementButtons.razor.cs
@@ -3,8 +3,9 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using LivingMessiah.Web.Services;
-using LivingMessiah.Web.Pages.Sukkot.Services;
+using LivingMessiah.Web.Pages.Sukkot.RegistrationEntry;
 using Blazored.Toast.Services;
+
 
 namespace LivingMessiah.Web.Pages.Sukkot.RegistrationSteps;
 
@@ -13,8 +14,8 @@ public partial class AgreementButtons
 	[Inject] public ILogger<AgreementButtons>? Logger { get; set; }
 	[Inject] AppState? AppState { get; set; }
 	[Inject] public IToastService? Toast { get; set; }
-	[Inject] public ISukkotService? svc { get; set; }
-	
+	[Inject] public IRepository? db { get; set; }
+
 	[Parameter, EditorRequired] public string? EmailParm { get; set; }
 
 	void DoNotAgree_ButtonClick()
@@ -30,17 +31,13 @@ public partial class AgreementButtons
 		await Task.Delay(0);
 		Logger!.LogDebug(string.Format("Event: {0} clicked"
 			, nameof(AgreementButtons) + "!" + nameof(Agree_ButtonClick)));
-		//int id = 0;
+		int id = 0;
 		try
 		{
-/*			
-			id = await svc!.AddHouseRulesAgreementRecord(EmailParm!, GetLocalTimeZone());
+			id = await db!.InsertHouseRulesAgreement(EmailParm!, GetLocalTimeZone());
 			Logger!.LogDebug(string.Format("...returned id: {0}", id));
-			AppState!.UpdateMessage(this, "Record updated for House Rules Agreement");
 			Toast!.ShowInfo($"Record updated for House Rules Agreement");
-*/
-			Toast!.ShowInfo($"ToDo: THIS NEEDS TO BE FIXED");
-
+						AppState!.UpdateMessage(this, "Record updated for House Rules Agreement");
 		}
 		catch (InvalidOperationException invalidOperationException)
 		{


### PR DESCRIPTION
2. Fixed the bug where the Sukkot Admin didn't see a link to Sukkot!RegistrationEntry!SuperUser!Index
3. Fixed the bug which occurred if a user typed in a url to sukkot details page that was not theirs.

# Details
## 1.  HRA agreement logic was incomplete
Reg step 3 (Add HRA) didn't work. The reason is because the service the `AgreementButtons` component was using had been deleted and if the agree button in the UI was clicked it would show a Toast saying "THIS NEEDS TO BE FIXED".

### Old Code
```csharp
[Inject] public ISukkotService? svc { get; set; }
//...
id = await svc!.AddHouseRulesAgreementRecord(EmailParm!, GetLocalTimeZone());
Toast!.ShowInfo($"ToDo: THIS NEEDS TO BE FIXED");
```

### New Code
```csharp
using LivingMessiah.Web.Pages.Sukkot.RegistrationEntry;
  [Inject] public IRepository? db { get; set; }
id = await db!.InsertHouseRulesAgreement(EmailParm!, GetLocalTimeZone());
```

### 2.  Super User Link missing
The Sukkot Admin user didn't have a link on the home page to the new Sukkot Super User page so I created a new component similar to **AudioVisualButton** and called it **SukkotAdminButton**

### 3.  sukkot details exception not handled properly
if a user typed in the url to a sukkot details page that was not theirs the service would detect that it wasn't theirs and throw an `UserNotAuthoirizedException` error; however the code behind **Pages.Sukkot.Details.Index** did not catch it so an unhandled exception was trhow