### PR TITLE
Pulled current date (Greg. and Heb. ) to SecondRowDates component

### DIFF
--- a/LivingMessiah.Web/Features/FeastDayPlanner/Data/Service.cs
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/Data/Service.cs
@@ -10,7 +10,6 @@ public interface IService
 {
 	HeaderServiceModel GetHeaderServiceModel(FeastDayType feastDay);
 	LunarMonths.ProgressBarVM GetHeaderServiceModelLunarMonth(LunarMonthType lunarMonth);
-
 }
 
 public class Service : IService
@@ -78,9 +77,6 @@ public class Service : IService
 			);
 
 		HeaderServiceModel model = new HeaderServiceModel();
-
-		model.GregorianDate = today.ToString(DateFormat.FeastDayPlanner);
-		model.HebrewDate = today.ToTransliteratedHebrewDateString();
 
 		if (today >= feastDay!.Range.Min && today <= feastDay!.Range.Max)
 		{

--- a/LivingMessiah.Web/Features/FeastDayPlanner/DaysIndicatorBadgeXsSm.razor
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/DaysIndicatorBadgeXsSm.razor
@@ -2,11 +2,10 @@
 @using LivingMessiah.Web.Infrastructure
 @using Microsoft.Extensions.Logging;
 
-@* @inject ILogger<DaysIndicatorBadgeXsSm>? Logger *@
 @inject Data.IService? svc
 
 <span class="badge @vm!.BadgeColor text-dark fw-bold fs-6">@vm!.DaysDifferentFormat</span> @vm!.SuffixDescription
-<p class="text-white my-1"><small>@vm!.GregorianDate | @vm!.HebrewDate</small></p>
+
 
 @code {
 	[Parameter, EditorRequired] public FeastDayType? FeastDayType { get; set; }
@@ -15,9 +14,6 @@
 	protected override void OnParametersSet()
 	{
 		vm = svc!.GetHeaderServiceModel(FeastDayType!);
-		// Logger!.LogDebug(string.Format("Inside DaysIndicatorBadge; FeastDayType: .Name: {0}; .FirstAndLastDates: {1}"
-		// , FeastDayType!.Name, FeastDayType!.FirstAndLastDates));
-
 	}
 
 }

--- a/LivingMessiah.Web/Features/FeastDayPlanner/Header.razor
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/Header.razor
@@ -4,11 +4,8 @@
 @inject Data.IService? svc
 
 <div class="row mt-3">
-	<div class="col-3">
-		<p class="mt-3 text-center fw-bold">@vm!.GregorianDate</p>
-	</div>
 
-	<div class="col-6 text-center">
+	<div class="col-12 text-center">
 		<div class="card bg-primary text-white">
 			<div class="card-body">
 				<h4><i class="@FeastDayType!.Icon"></i> <b>@FeastDayType!.PlannerTitle</b> <span class="hebrew"> @FeastDayType!.Hebrew</span> </h4>
@@ -16,10 +13,6 @@
 			</div>
 		</div>
 		
-	</div>
-
-	<div class="col-3">
-		<p class="mt-3 text-center fw-bold">@vm.HebrewDate</p>
 	</div>
 
 </div>

--- a/LivingMessiah.Web/Features/FeastDayPlanner/HeaderServiceModel.cs
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/HeaderServiceModel.cs
@@ -6,7 +6,4 @@ public class HeaderServiceModel
 	public int DaysDifferent { get; set; } // = 0;
 	public string? DaysDifferentFormat { get; set; } // = "";
 	public string? SuffixDescription { get; set; } // = "Passed, Present or Future?";
-	public string? GregorianDate { get; set; }
-	public string? HebrewDate { get; set; }
-
 }

--- a/LivingMessiah.Web/Features/FeastDayPlanner/Index.razor
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/Index.razor
@@ -5,6 +5,8 @@
 	<h2><i class="fas fa-bread-slice"></i> Feast Planner</h2>
 </div>
 
+<SecondRowDates />
+
 <div class="@MediaQuery.XsOrSm.DivClass">
  	<HeaderXsSm CurrentFilter="CurrentFilter"
 							OnFilterSelected="@ReturnedFilter" /> 

--- a/LivingMessiah.Web/Features/FeastDayPlanner/SecondRowDates.razor
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/SecondRowDates.razor
@@ -1,0 +1,24 @@
+﻿@using LivingMessiah.Web.Infrastructure;
+
+<div class="row mt-0">
+	<div class="col-6">
+		<p class=""><small>@GregorianDate</small></p>
+	</div>
+	<div class="col-6">
+		<p class="float-end"><small>@HebrewDate</small></p>
+	</div>
+</div>
+
+@code {
+	protected string? GregorianDate;
+	protected string? HebrewDate;
+
+	protected override void OnInitialized()
+	{
+		base.OnInitialized();
+		(string gregorianDate, string hebrewDate) = DateUtil.GetCurrentGregorianAndHebrewDates();
+		GregorianDate = gregorianDate;
+		HebrewDate = hebrewDate;
+	}
+
+}

--- a/LivingMessiah.Web/Infrastructure/DateUtil.cs
+++ b/LivingMessiah.Web/Infrastructure/DateUtil.cs
@@ -69,6 +69,13 @@ public static class DateUtil
 		return dateTimeWithTime.Date;
 	}
 
+	public static (string, string) GetCurrentGregorianAndHebrewDates(int testAddDays = 0)
+	{
+		DateTime today = GetDateTimeWithoutTime(DateTime.Now.AddDays(testAddDays).AddHours(Utc.ArizonaUtcMinus7));
+		string gregorianDate = today.ToString(DateFormat.FeastDayPlanner);
+		string hebrewDate = today.ToTransliteratedHebrewDateString();
+		return (gregorianDate, hebrewDate);
+	}
 
 	public static int GetNextShabbatWeek()
 	{


### PR DESCRIPTION
# 168-add-SecondRowDates-to-calendar
- NameSpace: `LivingMessiah.Web.Features.FeastDayPlanner`

## Commit 
- [X] Pulled current date (Greg. and Heb. ) to SecondRowDates component


## Data/Services, HeaderServiceModel.cs and Infrastructure/DateUtl
- [X] Moved GregorianDate and HebrewDate logic to `DateUtl.GetCurrentGregorianAndHebrewDates`

## DaysIndicatorBadgeXsSm
- [X] Deleted dates from component as they are now located in SecondRowDates