### PR TITLE
Got Graphic Files Is Null to add to blob storage

### DIFF
--- a/LivingMessiah.Web/Features/Admin/Video/Data/SprocTuple.cs
+++ b/LivingMessiah.Web/Features/Admin/Video/Data/SprocTuple.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace LivingMessiah.Web.Features.Admin.Video.Data;
+
+public record SprocTuple(int AffectedRows, int ReturnValue, string ReturnMsg);
+
+/*
+var t = new SprocTupleVT(a: 1, b: 2);
+ExampleMethod(t);
+
+var sprocTupleVT =  new SprocTupleVT
+
+ToDo: test this code and see if it's a better approach
+ */
+public record SprocTupleVT(int AffectedRows, int ReturnValue, string ReturnMsg)
+{
+	public static implicit operator ValueTuple<int, int, string>(SprocTupleVT record)
+	{
+		return (record.AffectedRows, record.ReturnValue, record.ReturnMsg);
+	}
+}
+
+// Ignore Spelling:Sproc

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/BlobRecord.cs
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/BlobRecord.cs
@@ -1,0 +1,34 @@
+﻿namespace LivingMessiah.Web.Features.Admin.Video.GraphicFileIsNull;
+
+
+public record BlobRecord (int ShabbatWeekId, int WeeklyVideoTypeId, string? YouTubeId, string? GraphicFile); // FN: 1
+
+/*
+public record BlobRecord
+{
+public int ShabbatWeekId { get; set; }     // FN2
+public int WeeklyVideoTypeId { get; set; } // FN2
+public string? YouTubeId { get; set; }
+public string? GraphicFile { get; set; }
+
+}
+
+## FN1: These four types are init-only properties and cnce assigned, their values cannot be changed
+
+To do this in "long form" you would use `init` e.g...
+
+```
+public record AddEditState
+{
+	public Enums.FormMode? FormMode { get; init; }
+	// ...
+```
+
+see also `Response_Message_Action.cs` (Features\Admin\Video\Enums\) for another example
+
+## FN2: Note these two int's make up the unique index for the Sql Server table `dbo.WeeklyVideo`
+ `IX_WeeklyVideo_Unique ON dbo.WeeklyVideo ShabbatWeekId ASC,	WeeklyVideoTypeId ASC`
+
+I need an example in Blazor where a record is passed as a Parameter to components
+
+*/

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/Index.razor
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/Index.razor
@@ -2,12 +2,25 @@
 @using Page = LivingMessiah.Web.Links.Admin.Video.GraphicFileIsNull
 @using static LivingMessiah.Web.Services.Auth0
 
+@using Blazored.Toast.Services
+@inject IToastService? Toast
 
 <AuthorizeView Roles="@Roles.Admin">
 
 	<Authorized>
+
 		<IndexPageHeader />
-		<Table />
+
+		@if (_showDetail)
+		{
+			<ProcessChosenBlob YouTubeId="@_youTubeId"
+												 BlobFileName="@GraphicFile"
+												 ShabbatWeekId="ShabbatWeekId"
+												 OnProcessCompleted="ReturnedProccess" />
+		}
+
+		<Table OnBlobSelected=@ReturnedSelection />
+
 	</Authorized>
 
 	<NotAuthorized>
@@ -28,4 +41,47 @@
 
 @code {
 
+	private bool _showDetail = false;
+
+	#region EventCallbacks
+
+	private string? _youTubeId = null;
+	private string? GraphicFile = null;
+	private int ShabbatWeekId = 0;
+
+
+	private void ReturnedSelection(YouTubeAndFileVM vm)  // string blobFile
+	{
+		_youTubeId = vm.YouTubeId!;
+		GraphicFile = vm.GraphicFile!;
+		ShabbatWeekId = vm.ShabbatWeekId;
+		_showDetail = true;
+		//StateHasChanged();
+	}
+
+	private BlobRecord? _blobRecord;
+	private void ReturnedSelectionRec(BlobRecord rec)  // string blobFile
+	{
+		_blobRecord = rec;
+		_showDetail = true;
+		//StateHasChanged();
+	}
+
+
+	private string? _returnedTransactionMessage;
+	private void ReturnedTransactionMessage(string msg)
+	{
+		_returnedTransactionMessage = msg;
+		Toast!.ShowInfo($"Transaction Message: {nameof(ReturnedTransactionMessage)}");
+	}
+
+	private void ReturnedProccess(bool cancelClicked)
+	{
+		_showDetail = false;
+		if (cancelClicked)
+		{
+			Toast!.ShowInfo("Cancel button clicked, No processing of blob");
+		}
+	}
+	#endregion
 }

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/ProcessChosenBlob.razor
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/ProcessChosenBlob.razor
@@ -1,0 +1,51 @@
+﻿@using Blazored.Toast.Services
+@using Microsoft.Extensions.Logging
+
+@inject IToastService? Toast
+@inject Data.IRepository? db 
+@inject ILogger<ProcessChosenBlob>? Logger
+
+@if (_YouTubeId is not null)
+{
+	<div class="card border-warning mx-3 mb-3">
+		<img src='@($"http://img.youtube.com/vi/{YouTubeId}/{"maxresdefault.jpg"}")' class="card-img-top">
+
+		@* @($"Hello {this.Model.SomeProperty}") *@
+
+		<div class="card-header text-center"><h3>Chosen Blob</h3></div>
+
+		<div class="card-body">
+
+			<div class="container d-flex justify-content-between">
+				<p><b>YouTubeId</b>: @_YouTubeId</p>
+				<p><b>BlobFileName</b>: @_BlobFileName</p>
+			</div>
+
+			@* <p class="card-title">YouTubeId: @_YouTubeId | BlobFileName: @_BlobFileName</p> *@
+
+		</div>
+
+		<div class="card-footer text-body-secondary text-center">
+			<div class="d-grid gap-1 d-flex justify-content-end">
+			<button @onclick="ButtonClicked" type="button"
+							title="Add Blob" class="text-success btn-sm">
+				Process Blob <i class="fas fa-network-wired"></i>
+				@* fas fa-plus *@
+			</button>
+
+				<button @onclick="CancelClicked" type="button"
+								title="Cancel" class="btn-sm">
+								Cancel
+				</button>
+
+			</div>
+		</div>
+	</div>
+}
+else
+{
+	<p class="text-black-50 text-end"><small><sup>no blob chosen</sup></small></p>
+}
+
+
+

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/ProcessChosenBlob.razor.cs
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/ProcessChosenBlob.razor.cs
@@ -1,0 +1,68 @@
+using LivingMessiah.Web.Features.Admin.Video.Data;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace LivingMessiah.Web.Features.Admin.Video.GraphicFileIsNull;
+public partial class ProcessChosenBlob
+{
+	[Parameter, EditorRequired] public string? YouTubeId { get; set; }
+	[Parameter, EditorRequired] public string? BlobFileName { get; set; }
+	[Parameter, EditorRequired] public int ShabbatWeekId { get; set; }
+
+	[Parameter, EditorRequired] public EventCallback<bool> OnProcessCompleted { get; set; }  // <string>
+
+	protected string? _YouTubeId;
+	protected string? _BlobFileName;
+	protected int _ShabbatWeekId;
+
+	protected override void OnParametersSet()
+	{
+		_YouTubeId = YouTubeId;
+		_BlobFileName = BlobFileName;
+		_ShabbatWeekId = ShabbatWeekId;
+	}
+
+	private async Task ButtonClicked()
+	{
+		YouTubeAndFileVM vm = new();
+		vm.YouTubeId = _YouTubeId;
+		vm.GraphicFile = _BlobFileName;
+		vm.ShabbatWeekId = _ShabbatWeekId;
+		vm.WeeklyVideoTypeId = Enums.WeeklyVideoType.MainServiceEnglish.Value;
+		try
+		{
+			var DatabaseResult = await db!.WeeklyVideoUpdateGraphicFile(vm).ContinueWith(t => new SprocTuple(t.Result.Item1, t.Result.Item2, t.Result.Item3));
+
+			if (DatabaseResult.ReturnValue == 0)  //if (sprocTuple.Item2 == 0)
+			{
+				Logger!.LogInformation("{Class}!{Method}; {Command} successfully updated {GraphicFile} for Key1 {ShabbatWeekId} and Key2 {WeeklyVideoTypeId}  ", 
+					nameof(ProcessChosenBlob), nameof(ButtonClicked), nameof(db.WeeklyVideoUpdateGraphicFile), vm.GraphicFile, vm.ShabbatWeekId, vm.WeeklyVideoTypeId);
+				Toast!.ShowSuccess($"Graphic File Updated! ReturnValue: {DatabaseResult.ReturnValue}; ReturnMsg{DatabaseResult.ReturnMsg}");
+			}
+			else
+			{
+				Toast!.ShowWarning($"{nameof(ProcessChosenBlob)}!{nameof(ButtonClicked)} Clicked; ReturnMsg{DatabaseResult.ReturnMsg}");
+			}
+
+		}
+		catch (Exception ex)
+		{
+			Logger!.LogError(ex, "{Class}!{Method}; {Command}", nameof(ProcessChosenBlob), nameof(ButtonClicked), nameof(db.WeeklyVideoUpdateGraphicFile));
+			Toast!.ShowError($"{Global.ToastShowError} {nameof(ProcessChosenBlob)}, {nameof(ButtonClicked)}");
+		}
+
+		finally
+		{
+			await OnProcessCompleted.InvokeAsync(false); 
+		}
+
+	}
+
+	private void CancelClicked()
+	{
+		OnProcessCompleted.InvokeAsync(true);
+	}
+
+}

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/Table.razor
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/Table.razor
@@ -21,6 +21,7 @@
 				@context.ShabbatWeekIdFileName <br />
 				@context.ShabbatDate.ToString(DateFormat.YYYY_MM_DD) <br />
 				@context.YouTubeId <br />
+				@context.ShabbatWeekId <br />
 				@context.TorahFileName
 			</td>
 
@@ -35,18 +36,12 @@
 			<td>@context.BlobFileName</td>
 
 			<td>
-				ToDo
+				@* <button @onclick="@(e => ButtonClicked(context.BlobFileName))" type="button" *@
+				<button @onclick="@(e => ButtonClicked(context.YouTubeId!, context.BlobFileName, context.ShabbatWeekId))" type="button"
+								title="Add Blob" class="text-success btn-sm">
+					<i class="fas fa-plus"></i>
+				</button>
 			</td>
-
-			@*
-
-
-			<button @onclick="@(e => Edit_ButtonClick(context.Id))" type="button"
-			title="Weekly Video Edit" class="@Enums.Crud.Edit.ButtonColor btn-sm">
-			<sup class="text-black-50">@context.Id</sup> <i class="@Enums.Crud.Edit.Icon"></i>
-			</button>
-
-			*@
 
 			@* <td>@context.GraphicFile</td> *@
 
@@ -55,6 +50,9 @@
 </LoadingComponent>
 
 @code {
+
+	[Parameter, EditorRequired] public EventCallback<YouTubeAndFileVM> OnBlobSelected { get; set; }  // EventCallback<string>
+
 	protected bool TurnSpinnerOff = false;
 	List<GraphicFileIsNull.GraphicFileIsNullVM>? GraphicFileIsNullList;
 
@@ -74,5 +72,15 @@
 		{
 			TurnSpinnerOff = true;
 		}
+	}
+
+	private void ButtonClicked(string youTubeId, string blobFileName, int shabbatWeekId)
+	{
+		YouTubeAndFileVM vm = new();
+		vm.YouTubeId = youTubeId;
+		vm.GraphicFile = blobFileName;
+		vm.ShabbatWeekId = shabbatWeekId;
+		OnBlobSelected.InvokeAsync(vm);
+		//OnBlobSelected.InvokeAsync(blobFileName);
 	}
 }

--- a/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/YouTubeAndFileVM.cs
+++ b/LivingMessiah.Web/Features/Admin/Video/GraphicFileIsNull/YouTubeAndFileVM.cs
@@ -1,0 +1,11 @@
+﻿namespace LivingMessiah.Web.Features.Admin.Video.GraphicFileIsNull;
+
+public class YouTubeAndFileVM
+{
+	// IX_WeeklyVideo_Unique ON dbo.WeeklyVideo ShabbatWeekId ASC,	WeeklyVideoTypeId ASC
+	public int ShabbatWeekId { get; set; }
+	public int WeeklyVideoTypeId { get; set; }
+	
+	public string? YouTubeId { get; set; }
+	public string? GraphicFile { get; set; }
+}

--- a/LivingMessiah.Web/Features/Admin/Video/Models/VideoImage.cs
+++ b/LivingMessiah.Web/Features/Admin/Video/Models/VideoImage.cs
@@ -22,7 +22,6 @@ public void Dump()
 Severity	Code	Description	Project	File	Line	Suppression State
 Error	CS0446	Foreach cannot operate on a 'method group'. Did you intend to invoke the 'method group'?	LivingMessiah.Web	C:\Users\JohnM\source\repos\LivingMessiahBlazor\LivingMessiah.Web\Features\Admin\Video\Models\VideoImage.cs	34	Active
 
-
 */
 
 public record VideoImage(string VideoId, string FileName);
@@ -40,6 +39,7 @@ public static class VideoFactory
 		}
 	}
 
+	// ToDo review
 	public static List<VideoImage> PopulateVideoList()
 	{
 		var x = new List<VideoImage>

--- a/LivingMessiah.Web/Features/InDepthStudy/Index.razor
+++ b/LivingMessiah.Web/Features/InDepthStudy/Index.razor
@@ -1,21 +1,22 @@
 ﻿@page "/InDepthStudy"
 
+@using Page = LivingMessiah.Web.Links.IndepthStudy
 @using Blazored.Toast.Services
-@using Microsoft.AspNetCore.Components
+@* @using Microsoft.AspNetCore.Components *@
 @using Microsoft.Extensions.Logging
 @using System.Threading.Tasks
 
-@inject Data.IRepository? db
-@inject LivingMessiah.Web.Features.UpcomingEvents.Weekly.ICacheService svc
-@inject ILogger<CurrentInDepthStudyCard>? Logger
-@inject IToastService? Toast
-
-@using Page = LivingMessiah.Web.Links.IndepthStudy
 <PageTitle>@Page.Title</PageTitle>
 
 <div class="pb-2 mt-4 mb-4 border-bottom">
 	<h2><i class="@Page.Icon"></i> @Page.Title</h2>
 </div>
+
+
+@inject ILogger<Index>? Logger
+@inject IToastService? Toast 
+@inject Data.IRepository? db
+@* @inject LivingMessiah.Web.Features.UpcomingEvents.Weekly.ICacheService svc *@
 
 <ItineraryCard />
 


### PR DESCRIPTION

# Details
- [x] **Index**: Container for Authorization, <ProcessChosenBlob> and <Table>
  - [x] Added event callbacks `ReturnedSelection` and `ReturnedTransactionMessage`
  - [ ] refactor using `BlobRecord` as a parameter to pass around 
- [ ] **<ProcessChosenBlob>**: process the chosen blob
  - [x] add to database
  - [ ] upload image to azure blob
  - [ ] refactor using `BlobRecord` as a parameter to pass around 
- [ ] **<Table>**: Finished button that, indirectly, calls `<ProcessChosenBlob>`, has `EventCallback<YouTubeAndFileVM> OnBlobSelected`
- [x] **Repository**: Added `WeeklyVideoUpdateGraphicFile` which uses `dbo.stpWeeklyVideo_GraphicFile_Update`
- [x] **YouTubeAndFileVM**: Added this, will be replaced with **BlobRecord**
- [x] **Tuple**: Added SprocTuple.cs as a tuple wrapper around sprocs 
- [ ] **BlobRecord**: Used for future refactoring
- [ ] 

# Next
- [ ] **VideoImage** Review this, it has a hardcoded list of YouTubeId's and blob image file names (Features\Admin\Video\Models\VideoImage.cs)

![Dialog-working-but-list-is-stale](https://github.com/livingmessiah/LivingMessiahBlazor/assets/1078267/fcbd9f8d-9a6e-4a92-807d-e769da9a561c)

