### PR TITLE
Home/Header changes not yet checked in

### DIFF
--- a/LivingMessiah.Web/Features/Articles/Pesach.razor
+++ b/LivingMessiah.Web/Features/Articles/Pesach.razor
@@ -57,9 +57,13 @@
 			<b>Passover <i>Haggadah</i> - </b>  The Hebrew word <i>haggadah</i> literally means "the telling."
 			Typically, at traditional Passover celebrations, there is a booklet available for the participants to read and follow along as the story of the first Passover is told.
 			There are many forms of this booklet available on the Internet, from various other sources, or you may choose not to use one at all.
+			
 			Here is a <i>Haggadah</i> oriented towards <b>the House of Israel</b>
 			<a href="@Blobs.UrlPdfs("house-of-david-seder.pdf")" target="_blank"><b>Passover <i>Haggadah</i></b></a> <i class="fas fa-file-pdf"></i>
 			which you may print, copy and use if you would like.
+
+			Here is yet another <i>Haggadah</i> oriented towards <b>For Ephraim Israel</b> created by Bnei Yoseph
+			<a href="@Blobs.UrlPdfs("Passover-Seder-for-Ephraim-Israel.pdf")" target="_blank"><b>Passover <i>Haggadah</i></b></a> <i class="fas fa-file-pdf"></i>
 		</li>
 		<li>
 			<span class="text-warning"><i class="fa-li fas fa-caret-right"></i></span>

--- a/LivingMessiah.Web/Features/Calendar/LmmCalendarAdvertisement.razor
+++ b/LivingMessiah.Web/Features/Calendar/LmmCalendarAdvertisement.razor
@@ -34,17 +34,17 @@
 
 					@if (IsCollapsed)
 					{
-						<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+						<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 										class="btn-primary btn-sm  float-end">
 							Details <i class='fas fa-chevron-down'></i>
-						</Button>
+						</button>
 					}
 					else
 					{
-						<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+						<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 										class="btn-primary btn-sm float-end">
 							Hide <i class='fas fa-chevron-up'></i>
-						</Button>
+						</button>
 					}
 
 					<div class="lead">

--- a/LivingMessiah.Web/Features/Calendar/ManageKeyDates/Constants.cs
+++ b/LivingMessiah.Web/Features/Calendar/ManageKeyDates/Constants.cs
@@ -23,7 +23,7 @@ public static class Omer
 
 public static class Dates
 {
-	public const string _12_Passover = "4/22/2024";
+	public const string _12_Passover = "4/12/2025";
 	/*
 	Called by...
 	- Pages\Articles\Pesach.razor.cs

--- a/LivingMessiah.Web/Features/FeastDayPlanner/ToggleButton.razor
+++ b/LivingMessiah.Web/Features/FeastDayPlanner/ToggleButton.razor
@@ -1,16 +1,16 @@
 ﻿@if (IsCollapsed)
 {
-	<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+	<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 					class="btn btn-outline-primary btn-sm">
 		@ButtonLabel <i class='fas fa-chevron-down'></i>
-	</Button>
+	</button>
 }
 else
 {
-	<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+	<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 					class="btn btn-outline-primary btn-sm">
 		Hide <i class='fas fa-chevron-up'></i>
-	</Button>
+	</button>
 
 	@ChildContent
 }

--- a/LivingMessiah.Web/Features/Home/Header.razor
+++ b/LivingMessiah.Web/Features/Home/Header.razor
@@ -2,38 +2,69 @@
 <div class="card border-danger my-3">
 	<div class="card-header bg-danger">
 		<h1 class="text-center text-white ">
-				Lyrics, Liturgy and Teaching
-			</h1>
+			Lyrics, Liturgy and Teaching
+		</h1>
 	</div>
-	
+
 	<div class="body my-2">
-			<h3 class="text-center">
-				@Title
-			</h3>
+		<h3 class="text-center">
+			@Title
+		</h3>
 	</div>
-	
+
+@* 	
 	<div class="body">
-			<h3 class="text-center">
-				@Teaching
-			</h3>
-	</div>
+		<h3 class="text-center">
+			@Teaching
+		</h3>
+	</div> *@
 
 
-		<div class="card-footer">
-			<div class="text-center">
-				<a href="@PDF" target="_blank" title="@Title | @Teaching"
-			   class="btn btn-outline-danger btn-xl">
-					<span class="fs-4">PDF Download</span>
-						<i class="fas fa-file-download fa-fw fa-2x" aria-hidden="true"></i>
+	<div class="card-footer">
+		<div class="text-center">
+			<a href="@PDF" target="_blank" title="@Title | @Teaching"
+				 class="btn btn-outline-danger btn-xl">
+				<i class="fas fa-file-pdf fa-fw fa-2x"></i>
+				<span class="fs-4"> @Teaching</span>
+				<i class="fas fa-file-download fa-fw fa-2x" aria-hidden="true"></i>
+			</a>
+		</div>
+
+		@if (!string.IsNullOrEmpty(PDF2))
+		{
+			<div class="text-center mt-2">
+				<a href="@PDF2" target="_blank" title="@Title2"
+					 class="btn btn-outline-danger btn-xl">
+					<i class="fas fa-file-pdf fa-fw fa-2x"></i>
+					<span class="fs-4">@Title2</span>
+					<i class="fas fa-file-download fa-fw fa-2x" aria-hidden="true"></i>
 				</a>
 			</div>
+		}
+
+
+		@if (!string.IsNullOrEmpty(Link))
+		{
+			<div class="text-center mt-2">
+				<a href="@Link" target="_blank" title="@Title3"
+					 class="btn btn-outline-danger btn-xl">
+					<span class="fs-4">@Title3</span>
+					<i class="fas fa-external-link-square-alt fa-fw fa-2x" aria-hidden="true"></i>
+				</a>
+			</div>
+		}
+
 	</div>
 
 
 </div>
 
 @code {
-[Parameter, EditorRequired] public string? Title { get; set; }  
-[Parameter, EditorRequired] public string? Teaching { get; set; }
-[Parameter, EditorRequired] public string? PDF { get; set; }
+	[Parameter, EditorRequired] public string? Title { get; set; }
+	[Parameter, EditorRequired] public string? Teaching { get; set; }
+	[Parameter, EditorRequired] public string? PDF { get; set; }
+	[Parameter] public string? PDF2 { get; set; }
+	[Parameter] public string? Title2 { get; set; }
+	[Parameter] public string? Link { get; set; }
+	[Parameter] public string? Title3 { get; set; }
 }

--- a/LivingMessiah.Web/Features/Home/HebrewClassCard.razor
+++ b/LivingMessiah.Web/Features/Home/HebrewClassCard.razor
@@ -1,0 +1,32 @@
+﻿
+<div class="card border-success mt-5 mb-3 ">
+	<div class="card-header bg-success">
+		<h1 class="text-center text-white ">
+			Hebrew Class
+		</h1>
+	</div>
+
+ 	<div class="body">
+		<h5 class="text-center p-3">
+			Bney Yosef North America Hebrew Class
+		</h5>
+	</div> 
+
+	<div class="card-footer">
+		<div class="text-center">
+			<a href="@PDF" target="_blank" title=""
+				 class="btn btn-outline-success btn-xl">
+				<i class="fas fa-file-pdf fa-fw fa-2x"></i>
+				<span class="fs-4">PDF</span>
+				<i class="fas fa-file-download fa-fw fa-2x" aria-hidden="true"></i>
+			</a>
+		</div>
+	</div>
+
+
+</div>
+
+@code {
+	//[Parameter, EditorRequired] public string? Teaching { get; set; }
+	[Parameter, EditorRequired] public string? PDF { get; set; }
+}

--- a/LivingMessiah.Web/Features/Home/Index.razor
+++ b/LivingMessiah.Web/Features/Home/Index.razor
@@ -7,9 +7,25 @@
 <PageTitle>@Page.PageTitle</PageTitle>
 <HomeImage></HomeImage>
 
-<Header Title="2024 Dec 21"
-				Teaching="Genesis 11"
-				PDF="https://livingmessiahstorage.blob.core.windows.net/shabbat-service/2024-12-21-Gen-11.pdf" />
+@*
+	
+	2025-05-31-Gen-32-04-to-33-17
+<Header Title="2025 May 03"
+				Teaching="Lyrics and Liturgy Only"
+				PDF="https://livingmessiahstorage.blob.core.windows.net/shabbat-service/2025-04-26-Gen-28-10-to-29-30.pdf"
+				PDF2="https://livingmessiahstorage.blob.core.windows.net/shabbat-service/2025-04-26-Gen-28-10-to-29-30-Gods-Sovereign-Control-Over-Hearts.pdf"
+				Title2 ="Gods Sovereign Control Over Hearts"
+				Link="https://docs.google.com/presentation/d/e/2PACX-1vQ0RGqOWaGaXticIbw7_mt4a8f3qHdrHLR-Zkm5Fux5TQWxyZFbsMq8zekeZS5RVv4BpVke8QVRJiXB/pub?start=false&loop=false&delayms=3000&pli=1&slide=id.g351ce096e70_0_133"
+				Title3="The Will of YHVH" />
+
+*@
+
+<Header Title="2025 May 31 | Genesis 32:4-33:17"
+				Teaching="Pdf Download"
+				PDF="https://livingmessiahstorage.blob.core.windows.net/shabbat-service/2025-05-31-Gen-32-04-to-33-17.pdf" />
+				                                                                        
+				     
+<HebrewClassCard PDF="https://livingmessiahstorage.blob.core.windows.net/shabbat-service/2025-02-08-Hebrew-Class.pdf"/>	
 
 <div class="@MediaQuery.XsOrSm.DivClass">
 	<RoleBasedLinks />

--- a/LivingMessiah.Web/Features/LunarMonths/ToggleButton.razor
+++ b/LivingMessiah.Web/Features/LunarMonths/ToggleButton.razor
@@ -1,16 +1,16 @@
 ﻿@if (IsCollapsed)
 {
-	<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+	<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 					class="btn btn-outline-primary btn-sm">
 		@ButtonLabel <i class='fas fa-chevron-down'></i>
-	</Button>
+	</button>
 }
 else
 {
-	<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+	<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 					class="btn btn-outline-primary btn-sm">
 		Hide <i class='fas fa-chevron-up'></i>
-	</Button>
+	</button>
 
 	@ChildContent
 }

--- a/LivingMessiah.Web/Features/ShabbatService/CardWithToggleVisiblity.razor
+++ b/LivingMessiah.Web/Features/ShabbatService/CardWithToggleVisiblity.razor
@@ -16,17 +16,17 @@
 		{
 			@if (IsCollapsed)
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn btn-primary btn-sm  float-end">
 					Detail <i class='fas fa-chevron-down'></i>
-				</Button>
+				</button>
 			}
 			else
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn btn-primary btn-sm float-end">
 					Hide <i class='fas fa-chevron-up'></i>
-				</Button>
+				</button>
 
 			}
 		}

--- a/LivingMessiah.Web/Features/ShabbatService/Liturgy.razor
+++ b/LivingMessiah.Web/Features/ShabbatService/Liturgy.razor
@@ -16,17 +16,17 @@
 		{
 			@if (IsCollapsed)
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn btn-primary btn-sm float-end">
 					Detail <i class='fas fa-chevron-down'></i>
-				</Button>
+				</button>
 			}
 			else
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn btn-primary btn-sm float-end">
 					Hide <i class='fas fa-chevron-up'></i>
-				</Button>
+				</button>
 			}
 		}
 	</div>

--- a/LivingMessiah.Web/Features/ShabbatService/PsaAndProComponent.razor
+++ b/LivingMessiah.Web/Features/ShabbatService/PsaAndProComponent.razor
@@ -16,17 +16,17 @@
 		{
 			@if (IsCollapsed)
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn-primary btn-sm  float-end">
 					Detail <i class='fas fa-chevron-down'></i>
-				</Button>
+				</button>
 			}
 			else
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn-primary btn-sm float-end">
 					Hide <i class='fas fa-chevron-up'></i>
-				</Button>
+				</button>
 
 			}
 		}

--- a/LivingMessiah.Web/Features/ShabbatService/ThankYou.razor
+++ b/LivingMessiah.Web/Features/ShabbatService/ThankYou.razor
@@ -16,17 +16,17 @@
 		{
 			@if (IsCollapsed)
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn-primary btn-sm  float-end">
 					Detail <i class='fas fa-chevron-down'></i>
-				</Button>
+				</button>
 			}
 			else
 			{
-				<Button @onclick="Collapsed_ButtonClick"
+				<button @onclick="Collapsed_ButtonClick"
 								class="btn-primary btn-sm float-end">
 					Hide <i class='fas fa-chevron-up'></i>
-				</Button>
+				</button>
 
 			}
 		}

--- a/LivingMessiah.Web/Features/Sukkot/ManageRegistration/Data/RepositoryHierarchicalQuery.cs
+++ b/LivingMessiah.Web/Features/Sukkot/ManageRegistration/Data/RepositoryHierarchicalQuery.cs
@@ -77,7 +77,7 @@ ORDER BY Detail
 		log.LogDebug(String.Format("Inside {0}, Sql={1}"
 			, nameof(RepositoryHierarchicalQuery) + "!" + nameof(GetDisplayAndDonationsById), base.Sql));
 
-		Detail.DetailAndDonationsHierarchicalQuery qry = new();
+		Detail.DetailAndDonationsHierarchicalQuery? qry = new();
 		string errMsg = "";
 		try
 		{
@@ -126,16 +126,16 @@ ORDER BY Detail
 
 	}
 
-	public string? Sql { get; set; }
-	public DynamicParameters? Parms { get; set; }  // using Dapper; Note, only place dependent on Dapper
+	public new string? Sql { get; set; }
+	public DynamicParameters? Params { get; set; }  // using Dapper; Note, only place dependent on Dapper
 
-	public string? SqlDump
+	public new string? SqlDump
 	{
 		get
 		{
 			string s = "";
 			s = Sql ?? "SQL IS NULL";
-			if (Parms != null)
+			if (Params != null)
 			{
 				/* See Notes in LivingMessiah.Data!BaseRepositoryAsync*/
 			}

--- a/LivingMessiah.Web/Features/Sukkot/NormalUser/Toggle.razor
+++ b/LivingMessiah.Web/Features/Sukkot/NormalUser/Toggle.razor
@@ -3,17 +3,17 @@
 	<div class="col-12">
 		@if (IsCollapsed)
 		{
-			<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+			<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 						class="btn-primary btn-sm float-end">
 				Form Details <i class='fas fa-chevron-down'></i>
-			</Button>
+			</button>
 		}
 		else
 		{
-			<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+			<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 						class="btn-primary btn-sm float-end">
 				Hide <i class='fas fa-chevron-up'></i>
-			</Button>
+			</button>
 		}
 	</div>
 </div>

--- a/LivingMessiah.Web/Features/Sukkot/RegistrationSteps/CheckSpamFolderTogleButton.razor
+++ b/LivingMessiah.Web/Features/Sukkot/RegistrationSteps/CheckSpamFolderTogleButton.razor
@@ -2,10 +2,10 @@
 
 <div class="row mb-3">
 	<div class="col-12">
-		<Button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
+		<button @onclick="@(e => ToggleButtonClick(IsCollapsed))"
 						class="btn-info btn-lg">
 			Email Verification Help <i class='@Chevron'></i>
-		</Button>
+		</button>
 	</div>
 </div>
 


### PR DESCRIPTION
# Commit | branch: john-193-Home-PDF-Download

### This is to get ready for the 194-Update-to-DotNet8
I had stuff not checked in

**Note**, I'm getting publish errors, [see](https://x.com/i/grok/share/7YLBiYZu4Quoh0mvq8VxUWAg4) because the publish process is using .Net 9 and it can't find the 7 sdk `dotnet --list-sdks`, so rather than screw with that, I'm just going to update from .net 7 to .net 8 -> 9

1. Articles/Pesach `<a href="@Blobs.UrlPdfs("Passover-Seder-for-Ephraim-Israel.pdf")"`
2. ManageKeyDate/Constants ` const string _12_Passover = "4/12/2025";`
3. Bunch of stupid Html errors `<Button` change to `<button`

#### 4. Home/Header
- Hebrew Teaching pdf
  - PDF2 title/link
- HebrewClassCard
- Index

#### 5. Sukkot/ManageRegistration/Data!RepositoryHierarchicalQuery 
`Detail.DetailAndDonationsHierarchicalQuery? qry = new();` ... probably didn't adequately test this 


